### PR TITLE
[CODEMOD]: Migrate to Node 24

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-v20.11.0
+lts/krypton

--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ inputs:
     required: true
     default: '[]'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
         "@commitlint/prompt-cli": "^19.8.1",
-        "@types/node": "^20.11.0",
+        "@types/node": "^24.0.0",
         "@typescript-eslint/eslint-plugin": "^5.56.0",
         "@typescript-eslint/parser": "^5.56.0",
         "@vercel/ncc": "^0.38.3",
@@ -28,7 +28,7 @@
         "typescript": "^5.9.2"
       },
       "engines": {
-        "node": ">=20.11.0"
+        "node": ">=24 <25"
       }
     },
     "node_modules/@actions/core": {
@@ -1970,12 +1970,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.19.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.13.tgz",
-      "integrity": "sha512-yCAeZl7a0DxgNVteXFHt9+uyFbqXGy/ShC4BlcHkoE0AfGXYv/BUiplV72DjMYXHDBXFjhvr6DD1NiRVfB4j8g==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/semver": {
@@ -4388,10 +4389,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",
@@ -6097,12 +6099,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.19.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.13.tgz",
-      "integrity": "sha512-yCAeZl7a0DxgNVteXFHt9+uyFbqXGy/ShC4BlcHkoE0AfGXYv/BUiplV72DjMYXHDBXFjhvr6DD1NiRVfB4j8g==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "requires": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "@types/semver": {
@@ -7780,9 +7782,9 @@
       }
     },
     "undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true
     },
     "unicorn-magic": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
     "@commitlint/prompt-cli": "^19.8.1",
-    "@types/node": "^20.11.0",
+    "@types/node": "^24.0.0",
     "@typescript-eslint/eslint-plugin": "^5.56.0",
     "@typescript-eslint/parser": "^5.56.0",
     "@vercel/ncc": "^0.38.3",
@@ -37,6 +37,6 @@
     "typescript": "^5.9.2"
   },
   "engines": {
-    "node": ">=20.11.0"
+    "node": ">=24 <25"
   }
 }


### PR DESCRIPTION
## Summary
- Branch: `#4-migrate-to-node-24` (commit `ad89c92`)
- Files changed: `.nvmrc`, `package.json`, `package-lock.json`, `action.yml`
- Node runtime moved to 24 (`lts/krypton`, engines `>=24 <25`, `@types/node` to `^24.0.0`, action runtime `node24`)
- `npm i` updated lockfile (`@types/node` resolved to `24.12.4`, `undici-types` to `7.16.0`)
- EBADENGINE warning: `@shiftcode/branch-utilities@5.0.2` supports `^20 || ^22`, not Node 24; changelog notes include breaking changes in 5.0.0 and Node runtime requirement change in 4.0.0

## Codemod notes
- No additional codemod-specific instructions were found in this workspace.

## Verification
- `npm run build` ✅
- `npm test` ⚠️ Missing script `test` (no test-like script present)

closes #4